### PR TITLE
Remove vestigial .JuliaFormatter.toml (repo uses Runic)

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-# See https://domluna.github.io/JuliaFormatter.jl/stable/ for a list of options


### PR DESCRIPTION
## Summary

Removes the empty, vestigial `.JuliaFormatter.toml`.

This repository is formatted with [Runic](https://github.com/fredrikekre/Runic.jl) (see the two "Runic formatting" commits), **not** JuliaFormatter. Runic is zero-config, so no replacement file is needed.

The leftover empty JuliaFormatter config only signalled the wrong formatter — running `JuliaFormatter.format(".")` reformats the entire codebase to a different style (spaces in type params, `for i in 1:n`, etc. all get changed). No CI references JuliaFormatter, so nothing depends on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
